### PR TITLE
Added net-dns/avahi as a dependency

### DIFF
--- a/x11-misc/barrier/barrier-2.3.2.ebuild
+++ b/x11-misc/barrier/barrier-2.3.2.ebuild
@@ -17,6 +17,7 @@ RESTRICT="test"
 DEPEND="
 	!libressl? ( dev-libs/openssl:* )
 	libressl? ( dev-libs/libressl )
+	net-dns/avahi
 	net-misc/curl
 	x11-libs/libICE
 	x11-libs/libSM


### PR DESCRIPTION
Compiling barrier without having net-dns/avahi results in the following error:

```
-- Checking for module 'avahi-compat-libdns_sd'                                                                                     
--   Package 'avahi-compat-libdns_sd', required by 'virtual:world', not found
CMake Error at /usr/share/cmake/Modules/FindPkgConfig.cmake:457 (message):
  A required package was not found
Call Stack (most recent call first):                                                                                                
  /usr/share/cmake/Modules/FindPkgConfig.cmake:642 (_pkg_check_modules_internal)
  CMakeLists.txt:171 (pkg_check_modules)
```